### PR TITLE
EOS-12019: Update the efs interface to call new api for read and write

### DIFF
--- a/src/dstore/dstore_base.c
+++ b/src/dstore/dstore_base.c
@@ -318,6 +318,14 @@ void dstore_io_op_fini(struct dstore_io_op *op)
 	log_trace("%s", (char *) "fini <<< ()");
 }
 
+ssize_t dstore_get_bsize(struct dstore *dstore, dstore_oid_t *oid)
+{
+	dassert(dstore && oid);
+	dassert(dstore_invariant(dstore));
+
+	return dstore->dstore_ops->obj_get_bsize(oid);
+}
+
 static int pwrite_aligned(struct dstore_obj *obj, char *write_buf,
 			  size_t buf_size, off_t offset)
 {
@@ -669,7 +677,7 @@ int dstore_pwrite(struct dstore_obj *obj, off_t offset, size_t count,
 		rc = pwrite_unaligned(obj, offset, count, bs, buf);
 	}
 
-	log_trace("dstore_io_op_pwrite:(" OBJ_ID_F " <=> %p )"
+	log_trace("dstore_pwrite:(" OBJ_ID_F " <=> %p )"
 		  "offset = %lu size = %lu rc = %d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj, offset, count, rc);
 	return rc;
@@ -692,7 +700,7 @@ int dstore_pread(struct dstore_obj *obj, off_t offset, size_t count,
 		rc = pread_unaligned(obj, offset, count, bs, buf);
 	}
 
-	log_trace("dstore_io_op_pread:(" OBJ_ID_F " <=> %p )"
+	log_trace("dstore_pread:(" OBJ_ID_F " <=> %p )"
 		  "offset = %lu size = %lu rc = %d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj, offset, count, rc);
 	return rc;

--- a/src/dstore/dstore_internal.h
+++ b/src/dstore/dstore_internal.h
@@ -470,6 +470,9 @@ struct dstore_ops {
 	 * (free(NULL) is noop).
 	 */
 	void (*free_buf)(struct dstore *, void *);
+
+	/* This function returns block size */
+	ssize_t (*obj_get_bsize) (dstore_oid_t *oid);
 };
 
 static inline
@@ -493,6 +496,7 @@ bool dstore_ops_invariant(const struct dstore_ops *ops)
 		ops->io_op_init &&
 		ops->io_op_submit &&
 		ops->io_op_wait &&
+		ops->obj_get_bsize &&
 
 		/* AllocBuf/FreeBuf interfaces are not in use right now. */
 #if 0

--- a/src/dstore/plugins/cortx/cortx_dstore.c
+++ b/src/dstore/plugins/cortx/cortx_dstore.c
@@ -639,6 +639,16 @@ static void cortx_ds_io_op_fini(struct dstore_io_op *dop)
 	m0_free(op);
 }
 
+ssize_t cortx_ds_obj_get_bsize(dstore_oid_t *oid)
+{
+	ssize_t bsize;
+	struct m0_uint128 fid;
+	m0_fid_copy((struct m0_uint128 *)oid, &fid);
+	bsize = m0store_get_bsize(fid);
+	log_debug("cortx_ds_obj_get_bsize bsize %lu", bsize);
+	return bsize;
+}
+
 const struct dstore_ops cortx_dstore_ops = {
 	.init = cortx_ds_init,
 	.fini = cortx_ds_fini,
@@ -654,4 +664,5 @@ const struct dstore_ops cortx_dstore_ops = {
 	.io_op_submit = cortx_ds_io_op_submit,
 	.io_op_wait = cortx_ds_io_op_wait,
 	.io_op_fini = cortx_ds_io_op_fini,
+	.obj_get_bsize = cortx_ds_obj_get_bsize,
 };

--- a/src/include/dstore.h
+++ b/src/include/dstore.h
@@ -141,7 +141,10 @@ typedef void (*dstore_io_op_cb_t)(void *cb_ctx,
 
 struct dstore *dstore_get(void);
 
-/** This API based on input decides whether the given request is aligned or not
+/* This api returns the block size from motr */
+ssize_t dstore_get_bsize(struct dstore *dstore, dstore_oid_t *oid);
+
+/** This API based on input decides whether the givevn request is aligned or not
  * If it is aligned request it will directly write the requested amount of data
  * to backend. If it is un-aligned then left and right aligned blocks might be
  * read-modify in to intermediate buffer location. Also rest of the aligned


### PR DESCRIPTION
Problem Statement :
EOS-12019: Update the efs interface to call new api for read and write
Problem Description:
Add a new api to dstore to fetch block size.
Solution Overview:
Added new api dstore_get_bsize().
Unit Test Cases:
EFS UT passes
