### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-dsal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.out
+*.o
+*.so*
+*.swp
+tags
+*.gdb_history
+TAGS
+*cortx-dsal.spec
+*cortx-dsal.pc
+build-dsal

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,9 +31,8 @@ DSAL_VERSION=${CORTXFS_VERSION:-"$(cat $DSAL_SOURCE_ROOT/VERSION)"}
 
 
 # Select DSAL Build Version.
-# Superproject: derived from cortxfs version.
-# Local: taken from git rev.
-DSAL_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of DSAL repo.
+DSAL_BUILD_VERSION=$(git -C $DSAL_SOURCE_ROOT rev-parse --short HEAD)
 
 # Optional, CORTX-UTILS source location.
 # Superproject: uses pre-defined location.


### PR DESCRIPTION
## Problem Statement:
https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-dsal

## Problem Description:
When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to the git repo.
```
git -C <path_to_git_repo> rev-parse --short HEAD
```

## Tests
Before Fix:
```
cortx-dsal-debuginfo-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-dsal-devel-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-dsal-1.0.0-7e45dd6.el7.x86_64.rpm
```
After Fix:
```
cortx-dsal-debuginfo-1.0.0-4c4bd39.el7.x86_64.rpm
cortx-dsal-devel-1.0.0-4c4bd39.el7.x86_64.rpm
cortx-dsal-1.0.0-4c4bd39.el7.x86_64.rpm
```
## Companion PRs
https://github.com/Seagate/cortx-utils/pull/10
https://github.com/Seagate/cortx-nsal/pull/5
https://github.com/Seagate/cortx-fs/pull/7
https://github.com/Seagate/cortx-fs-ganesha/pull/11