### PR TITLE
EOS-13064:Code cleanup for I/O path and modified truncate operation

### DIFF
--- a/src/dstore/dstore_internal.h
+++ b/src/dstore/dstore_internal.h
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 /* This file defines an API that is used and implemented by DSAL
@@ -365,23 +365,6 @@ struct dstore_ops {
 	int (*obj_delete) (struct dstore *dstore, void *ctx,
 			   dstore_oid_t *oid);
 
-	/* FIXME: Deprecated interface */
-	int (*obj_read) (struct dstore *dstore, void *ctx,
-			 dstore_oid_t *oid, off_t offset,
-			 size_t buffer_size, void *buffer, bool *end_of_file,
-			 struct stat *stat);
-
-	/* FIXME: Deprecated interface */
-	int (*obj_write) (struct dstore *dstore, void *ctx,
-			  dstore_oid_t *oid, off_t offset,
-			  size_t buffer_size,
-			  void *buffer, bool *fsal_stable, struct stat *stat);
-
-	/* FIXME: Deprecated interface */
-	int (*obj_resize) (struct dstore *dstore, void *ctx,
-			   dstore_oid_t *oid,
-		           size_t old_size, size_t new_size);
-
 	/*
 	 * TODO: This function does not have well-defined behavior
 	 * yet. This needs to be addressed.
@@ -487,9 +470,6 @@ bool dstore_ops_invariant(const struct dstore_ops *ops)
 		ops->fini &&
 		ops->obj_create &&
 		ops->obj_delete &&
-		ops->obj_read &&
-		ops->obj_write &&
-		ops->obj_resize &&
 		ops->obj_get_id &&
 		ops->obj_open &&
 		ops->obj_close &&

--- a/src/include/dstore.h
+++ b/src/include/dstore.h
@@ -98,13 +98,19 @@ int dstore_obj_write(struct dstore *dstore, void *ctx,
 		     size_t buffer_size, void *buffer, bool *fsal_stable,
 		     struct stat *stat);
 
-/* TODO: Should be replaced by dstore_io_op_deallocate?
- * XXX: Also, the name is not correct: the function deallocates
- * space but does not perform any changes of the object size.
+/* This API based on input size decides whether this is object shrink operation,
+ * extend operation or noop in case of both the size are same
+ * In case of noop/extend operation nothing needs to be done on particular
+ * object, extend is considered as hole and while reading user should be
+ * receiving all zeros for this range.
+ * In case of shrink, all zeroes will be written to backend obj store for given
+ * specified range
+ * @paramp[in] obj - An open object.
+ * @paramp[in] old_size - Current size of given object
+ * @paramp[in] new_size - New size of a given object after performing this op
+ * @return 0 on success -errno given by backend operation
  */
-int dstore_obj_resize(struct dstore *dstore, void *ctx,
-		      dstore_oid_t *oid,
-		      size_t old_size, size_t new_size);
+int dstore_obj_resize(struct dstore_obj *obj, size_t old_size, size_t new_size);
 
 int dstore_get_new_objid(struct dstore *dstore, dstore_oid_t *oid);
 

--- a/src/test/dsal_test_space_stats.c
+++ b/src/test/dsal_test_space_stats.c
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #include <stdio.h> /* *printf */
@@ -92,9 +92,9 @@ static void test_creat_big_objects(void **state)
 	size_t offset = 0;
 	void *raw_buf = NULL;
 	struct dstore_obj *obj = NULL;
-	bool written;
 	struct stat stats;
 	struct env *env = ENV_FROM_STATE(state);
+	size_t bsize  = 4 << 10;
 
 	memset(&stats, 0, sizeof(stats));
 	raw_buf = calloc(1, buf_size);
@@ -120,9 +120,9 @@ static void test_creat_big_objects(void **state)
 		for (j = 0; j < 100; j++) {
 			/* Using below API purposely, as it provides offset
 			   option which can be used to create big files */
-			rc = dstore_obj_write(env->dstore, NULL, &env->oids[i],
-				offset, buf_size, raw_buf, &written, &stats);
-			ut_assert_int_equal(rc, buf_size);
+			rc = dstore_pwrite(obj, offset, buf_size, bsize,
+					   raw_buf);
+			ut_assert_int_equal(rc, 0);
 			offset += buf_size;
 		}
 


### PR DESCRIPTION
# DSAL Change Summary

## Problem Statement

_[EOS-13064](https://jts.seagate.com/browse/EOS-13064):_
_Do the code clean up and remove old code in dsal.._

## Problem Description

_We have some of the legacy still reside in our repository which was  not being used so cleanup of that was required. During cleanup it was also found that the API which we intend to remove was still in use by truncate operation._

## Solution Overview

_So modified the truncate operation, cleanup the code wherever it was possible_

## Unit Test Cases
_All the DSAL, NSAL, Cortx-fs UTs are passing_
_Able to create, export and mount the FS, able to do basic I/O_
_cthon test is passing General, Basic, Lock test cases_
_Verified the truncate operation from NFS client and it is working, for further details about test cases visit [EOS-13064](https://jts.seagate.com/browse/EOS-13064)_

## Companion MRs
- https://github.com/Seagate/cortx-utils/pull/11
- https://github.com/Seagate/cortx-fs/pull/8

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing UTs are passing and related test cases are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-13064](https://jts.seagate.com/browse/EOS-13064) have up to date description_