### PR TITLE
EOS-14275: Add tracepoints for dstore_obj_ops operations (dsal changes)

### DIFF
--- a/src/dstore/dstore_base.c
+++ b/src/dstore/dstore_base.c
@@ -217,6 +217,8 @@ out:
 		  OBJ_ID_P(dstore_obj_id(obj)), obj, old_size, new_size,
 		  rc);
 
+	perfc_trace_attr(PEA_DSTORE_OLD_SIZE, old_size);
+	perfc_trace_attr(PEA_DSTORE_NEW_SIZE, new_size);
 	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
@@ -250,6 +252,8 @@ out:
 		  OBJ_ID_P(dstore_obj_id(obj)), obj, old_size, new_size,
 		  rc);
 
+	perfc_trace_attr(PEA_DSTORE_OLD_SIZE, old_size);
+	perfc_trace_attr(PEA_DSTORE_NEW_SIZE, new_size);
 	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 

--- a/src/dstore/dstore_base.c
+++ b/src/dstore/dstore_base.c
@@ -59,6 +59,8 @@ int dstore_init(struct collection_item *cfg, int flags)
 
 	assert(dstore && cfg);
 
+	perfc_trace_inii(PFT_DSTORE_INIT, PEM_DSTORE_TO_NFS);
+
 	RC_WRAP(get_config_item, "dstore", "type", cfg, &item);
 	if (item == NULL) {
 		fprintf(stderr, "dstore type not specified\n");
@@ -85,6 +87,10 @@ int dstore_init(struct collection_item *cfg, int flags)
 
 	assert(dstore->dstore_ops->init != NULL);
 	rc = dstore->dstore_ops->init(cfg);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	if (rc) {
 		return rc;
 	}
@@ -94,27 +100,51 @@ int dstore_init(struct collection_item *cfg, int flags)
 
 int dstore_fini(struct dstore *dstore)
 {
+	int rc;
 	assert(dstore && dstore->dstore_ops && dstore->dstore_ops->fini);
 
-	return dstore->dstore_ops->fini();
+	perfc_trace_inii(PFT_DSTORE_FINI, PEM_DSTORE_TO_NFS);
+
+	rc = dstore->dstore_ops->fini();
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+	return rc;
 }
 
 int dstore_obj_create(struct dstore *dstore, void *ctx,
 		      dstore_oid_t *oid)
 {
+	int rc;
 	assert(dstore && dstore->dstore_ops && oid &&
 	       dstore->dstore_ops->obj_create);
 
-	return dstore->dstore_ops->obj_create(dstore, ctx, oid);
+	perfc_trace_inii(PFT_DSTORE_OBJ_CREATE, PEM_DSTORE_TO_NFS);
+
+	rc = dstore->dstore_ops->obj_create(dstore, ctx, oid);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+	return rc;
 }
 
 int dstore_obj_delete(struct dstore *dstore, void *ctx,
 		      dstore_oid_t *oid)
 {
+	int rc;
 	assert(dstore && dstore->dstore_ops && oid &&
 	       dstore->dstore_ops->obj_delete);
 
-	return dstore->dstore_ops->obj_delete(dstore, ctx, oid);
+	perfc_trace_inii(PFT_DSTORE_OBJ_DELETE, PEM_DSTORE_TO_NFS);
+
+	rc = dstore->dstore_ops->obj_delete(dstore, ctx, oid);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+	return rc;
 }
 
 /* TODO: Can be removed when plugin API for removing objects from backend store
@@ -133,6 +163,8 @@ static int dstore_obj_shrink(struct dstore_obj *obj,  size_t old_size,
 	size_t count;
 	off_t offset;
 	char *tmp_buf = NULL;
+
+	perfc_trace_inii(PFT_DSTORE_OBJ_SHRINK, PEM_DSTORE_TO_NFS);
 
 	bsize = dstore_get_bsize(obj->ds,
 				 (dstore_oid_t *)dstore_obj_id(obj));
@@ -184,12 +216,18 @@ out:
 		  "old_size = %lu new_size = %lu rc = %d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj, old_size, new_size,
 		  rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 
 int dstore_obj_resize(struct dstore_obj *obj, size_t old_size, size_t new_size)
 {
 	int rc = 0;
+
+	perfc_trace_inii(PFT_DSTORE_OBJ_RESIZE, PEM_DSTORE_TO_NFS);
 
 	/* Following code handle two cases
 	 * 1. If old and new size are same it's a noop hence no change
@@ -211,15 +249,27 @@ out:
 		  "old_size = %lu new_size = %lu rc = %d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj, old_size, new_size,
 		  rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 
 int dstore_get_new_objid(struct dstore *dstore, dstore_oid_t *oid)
 {
+	int rc;
 	assert(dstore && oid && dstore->dstore_ops &&
 	       dstore->dstore_ops->obj_get_id);
 
-	return dstore->dstore_ops->obj_get_id(dstore, oid);
+	perfc_trace_inii(PFT_DSTORE_GET_NEW_OBJID, PEM_DSTORE_TO_NFS);
+
+	rc = dstore->dstore_ops->obj_get_id(dstore, oid);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+	return rc;
 }
 
 int dstore_obj_open(struct dstore *dstore,
@@ -232,6 +282,8 @@ int dstore_obj_open(struct dstore *dstore,
 	dassert(dstore);
 	dassert(oid);
 	dassert(out);
+
+	perfc_trace_inii(PFT_DSTORE_OBJ_OPEN, PEM_DSTORE_TO_NFS);
 
 	RC_WRAP_LABEL(rc, out, dstore->dstore_ops->obj_open, dstore, oid,
 		      &result);
@@ -250,6 +302,10 @@ out:
 
 	log_debug("open " OBJ_ID_F ", %p, rc=%d", OBJ_ID_P(oid),
 		  rc == 0 ? *out : NULL, rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 
@@ -262,6 +318,8 @@ int dstore_obj_close(struct dstore_obj *obj)
 	dstore = obj->ds;
 	dassert(dstore);
 
+	perfc_trace_inii(PFT_DSTORE_OBJ_CLOSE, PEM_DSTORE_TO_NFS);
+
 	log_trace("close >>> " OBJ_ID_F ", %p",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj);
 
@@ -269,6 +327,10 @@ int dstore_obj_close(struct dstore_obj *obj)
 
 out:
 	log_trace("close <<< (%d)", rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 
@@ -291,6 +353,8 @@ static int dstore_io_op_init_and_submit(struct dstore_obj *obj,
 	dassert(op_type == DSTORE_IO_OP_WRITE ||
 		op_type == DSTORE_IO_OP_READ);
 
+	perfc_trace_inii(PFT_DSTORE_IO_OP_INIT_AND_SUBMIT, PEM_DSTORE_TO_NFS);
+
 	dstore = obj->ds;
 
 	RC_WRAP_LABEL(rc, out, dstore->dstore_ops->io_op_init, obj,
@@ -305,6 +369,9 @@ out:
 		dstore->dstore_ops->io_op_fini(result);
 	}
 
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	dassert((!(*out)) || dstore_io_op_invariant(*out));
 	return rc;
 }
@@ -315,12 +382,17 @@ int dstore_io_op_write(struct dstore_obj *obj,
 {
 	int rc;
 
+	perfc_trace_inii(PFT_DSTORE_IO_OP_WRITE, PEM_DSTORE_TO_NFS);
+
 	rc = dstore_io_op_init_and_submit(obj, bvec, out, DSTORE_IO_OP_WRITE);
 
 	log_debug("write (" OBJ_ID_F " <=> %p, "
 		  "vec=%p, *out=%p) rc=%d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj,
 		  bvec, rc == 0 ? *out : NULL, rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
 	return rc;
 }
@@ -330,12 +402,17 @@ int dstore_io_op_read(struct dstore_obj *obj, struct dstore_io_vec *bvec,
 {
 	int rc;
 
+	perfc_trace_inii(PFT_DSTORE_IO_OP_READ, PEM_DSTORE_TO_NFS);
+
 	rc = dstore_io_op_init_and_submit(obj, bvec, out, DSTORE_IO_OP_READ);
 
 	log_debug("read (" OBJ_ID_F " <=> %p, "
 		  "vec=%p, *out=%p) rc=%d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj,
 		  bvec, rc == 0 ? *out : NULL, rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
 	return rc;
 }
@@ -350,6 +427,8 @@ int dstore_io_op_wait(struct dstore_io_op *op)
 	dassert(op->obj->ds);
 	dassert(dstore_io_op_invariant(op));
 
+	perfc_trace_inii(PFT_DSTORE_IO_OP_WAIT, PEM_DSTORE_TO_NFS);
+
 	dstore = op->obj->ds;
 
 	RC_WRAP_LABEL(rc, out, dstore->dstore_ops->io_op_wait, op);
@@ -357,6 +436,10 @@ int dstore_io_op_wait(struct dstore_io_op *op)
 out:
 	log_debug("wait (" OBJ_ID_F " <=> %p, op=%p) rc=%d",
 		  OBJ_ID_P(dstore_obj_id(op->obj)), op->obj, op, rc);
+
+	perfc_trace_attr(PEA_DSTORE_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 
@@ -369,6 +452,8 @@ void dstore_io_op_fini(struct dstore_io_op *op)
 	dassert(op->obj->ds);
 	dassert(dstore_io_op_invariant(op));
 
+	perfc_trace_inii(PFT_DSTORE_IO_OP_FINI, PEM_DSTORE_TO_NFS);
+
 	dstore = op->obj->ds;
 
 	log_trace("fini >>> (" OBJ_ID_F " <=> %p, op=%p)",
@@ -377,6 +462,8 @@ void dstore_io_op_fini(struct dstore_io_op *op)
 	dstore->dstore_ops->io_op_fini(op);
 
 	log_trace("%s", (char *) "fini <<< ()");
+
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 }
 
 static ssize_t __dstore_get_bsize(struct dstore *dstore, dstore_oid_t *oid)


### PR DESCRIPTION
# cortx-dsal Change Summary

## Problem Statement
_[EOS-14275](https://jts.seagate.com/browse/EOS-14275):_
_ADDB: Add tracepoints for dstore_obj_ops operations_

## Problem Description
_Add ADDB tracepoints in DSAL layer for dstore_obj_ops_

## Solution Overview
_Add trace points in all necessary dstore related functions_

## Unit Test Cases
_Full build, executed testing scripts_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0


CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 8
Tests failed = 1

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 8
Tests failed = 1

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0
```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [X] **Sanity Testing:** _Done_
- [ ] **Documentation:** _TBD_