### PR TITLE
EOS-14572: ADDB : Code refactor (dsal repo)

### DIFF
--- a/src/dstore/dstore_base.c
+++ b/src/dstore/dstore_base.c
@@ -30,6 +30,7 @@
 #include "dstore_internal.h" /* import internal API definitions */
 #include "dstore_bufvec.h" /* data buffers and vectors */
 #include "operation.h"
+#include <cfs_dsal_perfc.h>
 
 /* 20 MB is the max dealloc operation size that can be sent to motr code */
 #define DSAL_MAX_DEALLOC_OP_SIZE (20*1024*1024)

--- a/src/dstore/plugins/cortx/cortx_dstore.c
+++ b/src/dstore/plugins/cortx/cortx_dstore.c
@@ -33,6 +33,7 @@
 #include "debug.h" /* dassert */
 #include "lib/vec.h" /* m0bufvec and m0indexvec */
 #include "operation.h"
+#include <cfs_dsal_perfc.h>
 
 /** Private definition of DSTORE object for M0-based backend. */
 struct cortx_dstore_obj {
@@ -458,8 +459,8 @@ static int cortx_ds_io_op_init(struct dstore_obj *dobj,
 	}
 
 	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OBJ_OP);
-	perfc_trace_attr(PEA_M0_OP_SM_ID, result->cop->op_sm.sm_id);
-	perfc_trace_attr(PEA_M0_OP_SM_STATE, result->cop->op_sm.sm_state);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_ID, result->cop->op_sm.sm_id);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_STATE, result->cop->op_sm.sm_state);
 
 	result->cop->op_datum = result;
 	m0_op_setup(result->cop, &cortx_io_op_cbs, schedule_now);
@@ -486,13 +487,13 @@ static int cortx_ds_io_op_submit(struct dstore_io_op *dop)
 {
 	struct cortx_io_op *op = D2E_op(dop);
 	perfc_trace_inii(PFT_DS_IO_SUBMIT, PEM_DSAL_TO_MOTR);
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_LAUNCH);
+	perfc_trace_attr(PEA_TIME_ATTR_START_DSAL_M0_OP_LAUNCH);
 
 	m0_op_launch(&op->cop, 1);
 
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_LAUNCH);
-	perfc_trace_attr(PEA_M0_OP_SM_ID, op->cop->op_sm.sm_id);
-	perfc_trace_attr(PEA_M0_OP_SM_STATE, op->cop->op_sm.sm_state);
+	perfc_trace_attr(PEA_TIME_ATTR_END_DSAL_M0_OP_LAUNCH);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_ID, op->cop->op_sm.sm_id);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_STATE, op->cop->op_sm.sm_state);
 
 	log_debug("io_op_submit op=%p", op);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
@@ -509,17 +510,17 @@ static int cortx_ds_io_op_wait(struct dstore_io_op *dop)
 
 	perfc_trace_inii(PFT_DS_IO_WAIT, PEM_DSAL_TO_MOTR);
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_WAIT);
+	perfc_trace_attr(PEA_TIME_ATTR_START_DSAL_M0_OP_WAIT);
 	RC_WRAP_LABEL(rc, out, m0_op_wait, op->cop, wait_bits,
 		      time_limit);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_WAIT);
+	perfc_trace_attr(PEA_TIME_ATTR_END_DSAL_M0_OP_WAIT);
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_RC);
+	perfc_trace_attr(PEA_TIME_ATTR_START_DSAL_M0_RC);
 	RC_WRAP_LABEL(rc, out, m0_rc, op->cop);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_RC);
+	perfc_trace_attr(PEA_TIME_ATTR_END_DSAL_M0_RC);
 
-	perfc_trace_attr(PEA_M0_OP_SM_ID, op->cop->op_sm.sm_id);
-	perfc_trace_attr(PEA_M0_OP_SM_STATE, op->cop->op_sm.sm_state);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_ID, op->cop->op_sm.sm_id);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_STATE, op->cop->op_sm.sm_state);
 
 out:
 	log_debug("io_op_wait op=%p, rc=%d", op, rc);
@@ -535,16 +536,16 @@ static void cortx_ds_io_op_fini(struct dstore_io_op *dop)
 
 	perfc_trace_inii(PFT_DS_IO_FINISH, PEM_DSAL_TO_MOTR);
 
-	perfc_trace_attr(PEA_M0_OP_SM_ID, op->cop->op_sm.sm_id);
-	perfc_trace_attr(PEA_M0_OP_SM_STATE, op->cop->op_sm.sm_state);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_ID, op->cop->op_sm.sm_id);
+	perfc_trace_attr(PEA_M0_OP_DSAL_SM_STATE, op->cop->op_sm.sm_state);
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FINISH);
+	perfc_trace_attr(PEA_TIME_ATTR_START_DSAL_M0_OP_FINISH);
 	m0_op_fini(op->cop);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FINISH);
+	perfc_trace_attr(PEA_TIME_ATTR_END_DSAL_M0_OP_FINISH);
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FREE);
+	perfc_trace_attr(PEA_TIME_ATTR_START_DSAL_M0_OP_FREE);
 	m0_op_free(op->cop);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FREE);
+	perfc_trace_attr(PEA_TIME_ATTR_END_DSAL_M0_OP_FREE);
 
 	perfc_trace_attr(PEA_TIME_ATTR_START_M0_FREE);
 	m0_free(op);

--- a/src/include/cfs_dsal_perfc.h
+++ b/src/include/cfs_dsal_perfc.h
@@ -1,0 +1,119 @@
+/*
+ * Filename:	cfs_perfc.h
+ * Description:	This module defines performance counters and helpers.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+#ifndef __CFS_DSAL_PERF_COUNTERS_H_
+#define __CFS_DSAL_PERF_COUNTERS_H_
+/******************************************************************************/
+#include "perf/tsdb.h" /* ACTION_ID_BASE */
+#include "operation.h"
+#include <pthread.h>
+#include <string.h>
+#include "debug.h"
+#include "perf/perf-counters.h"
+
+enum perfc_dsal_function_tags {
+	PFT_DS_START = PFTR_RANGE_3_START,
+
+	PFT_DSTORE_GET,
+	PFT_DSTORE_PREAD,
+	PFT_DSTORE_PWRITE,
+
+	PFT_DS_INIT,
+	PFT_DS_FINISH,
+
+	PFT_DS_OBJ_GET_ID,
+	PFT_DS_OBJ_CREATE,
+	PFT_DS_OBJ_DELETE,
+	PFT_DS_OBJ_ALLOC,
+	PFT_DS_OBJ_FREE,
+	PFT_DS_OBJ_OPEN,
+	PFT_DS_OBJ_CLOSE,
+
+	PFT_DS_IO_INIT,
+	PFT_DS_IO_SUBMIT,
+	PFT_DS_IO_WAIT,
+	PFT_DS_IO_FINISH,
+
+	PFT_DSTORE_INIT,
+	PFT_DSTORE_FINI,
+	PFT_DSTORE_OBJ_CREATE,
+	PFT_DSTORE_OBJ_DELETE,
+	PFT_DSTORE_OBJ_SHRINK,
+	PFT_DSTORE_OBJ_RESIZE,
+	PFT_DSTORE_GET_NEW_OBJID,
+	PFT_DSTORE_OBJ_OPEN,
+	PFT_DSTORE_OBJ_CLOSE,
+	PFT_DSTORE_IO_OP_INIT_AND_SUBMIT,
+	PFT_DSTORE_IO_OP_WRITE,
+	PFT_DSTORE_IO_OP_READ,
+	PFT_DSTORE_IO_OP_WAIT,
+	PFT_DSTORE_IO_OP_FINI,
+
+	PFT_DS_END = PFTR_RANGE_3_END
+};
+
+enum perfc_dsal_entity_attrs {
+	PEA_DS_START = PEAR_RANGE_3_START,
+
+	PEA_DSTORE_OLD_SIZE,
+	PEA_DSTORE_NEW_SIZE,
+	PEA_DSTORE_GET_RES_RC,
+	PEA_DSTORE_PREAD_OFFSET,
+	PEA_DSTORE_PREAD_COUNT,
+	PEA_DSTORE_PREAD_RES_RC,
+	PEA_DSTORE_PWRITE_OFFSET,
+	PEA_DSTORE_PWRITE_COUNT,
+	PEA_DSTORE_PWRITE_RES_RC,
+	PEA_DSTORE_BS,
+
+	PEA_TIME_ATTR_START_M0_OBJ_OP,
+	PEA_TIME_ATTR_END_M0_OBJ_OP,
+	PEA_TIME_ATTR_START_DSAL_M0_OP_FINISH,
+	PEA_TIME_ATTR_END_DSAL_M0_OP_FINISH,
+	PEA_TIME_ATTR_START_DSAL_M0_OP_FREE,
+	PEA_TIME_ATTR_END_DSAL_M0_OP_FREE,
+	PEA_M0_OP_DSAL_SM_ID,
+	PEA_M0_OP_DSAL_SM_STATE,
+	PEA_DSTORE_RES_RC,
+
+	PEA_TIME_ATTR_START_DSAL_M0_OP_LAUNCH,
+	PEA_TIME_ATTR_END_DSAL_M0_OP_LAUNCH,
+	PEA_TIME_ATTR_START_DSAL_M0_OP_WAIT,
+	PEA_TIME_ATTR_END_DSAL_M0_OP_WAIT,
+	PEA_TIME_ATTR_START_DSAL_M0_RC,
+	PEA_TIME_ATTR_END_DSAL_M0_RC,
+	PEA_TIME_ATTR_START_M0_FREE,
+	PEA_TIME_ATTR_END_M0_FREE,
+	PEA_TIME_ATTR_START_M0_ALLOC_PTR,
+	PEA_TIME_ATTR_END_M0_ALLOC_PTR,
+
+	PEA_DS_END = PEAR_RANGE_3_END
+};
+
+enum perfc_dsal_entity_maps {
+	PEM_DS_START = PEMR_RANGE_3_START,
+
+	PEM_DSAL_TO_MOTR,
+	PEM_DSTORE_TO_NFS,
+
+	PEM_DS_END = PEMR_RANGE_3_END
+};
+
+/******************************************************************************/
+#endif /* __CFS_DSAL_PERF_COUNTERS_H_ */

--- a/src/include/cfs_dsal_perfc.h
+++ b/src/include/cfs_dsal_perfc.h
@@ -1,5 +1,5 @@
 /*
- * Filename:	cfs_perfc.h
+ * Filename:	cfs_dsal_perfc.h
  * Description:	This module defines performance counters and helpers.
  *
  * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates


### PR DESCRIPTION
#  EOS-14572: ADDB : Code refactor (dsal repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT
[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0


IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


commit 8625d5c979d5a5355319de60ca246b69db8c0b60
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Nov 2 17:03:17 2020 -0700

                EOS-14572: ADDB : Code refactor (dsal repo)
                List of modified files:
                modified:   src/dstore/dstore_base.c
                modified:   src/dstore/plugins/cortx/cortx_dstore.c
                new file:   src/include/cfs_dsal_perfc.h
                Change description:
                        Refactor function tags, maps and attribute enums and move out repo specific code. Introduce ranges. move out plugin.
                Test:
                        On VM: UT, addb traces and graphs
