### PR TITLE
EOS-15064: cortxfs perf: Expose bsize as a per file system configurable param and stop using m0store_get_bsize (repo dsal)

### DIFF
--- a/src/dstore/dstore_internal.h
+++ b/src/dstore/dstore_internal.h
@@ -468,9 +468,6 @@ struct dstore_ops {
 	 * (free(NULL) is noop).
 	 */
 	void (*free_buf)(struct dstore *, void *);
-
-	/* This function returns block size */
-	ssize_t (*obj_get_bsize) (dstore_oid_t *oid);
 };
 
 static inline
@@ -491,7 +488,6 @@ bool dstore_ops_invariant(const struct dstore_ops *ops)
 		ops->io_op_init &&
 		ops->io_op_submit &&
 		ops->io_op_wait &&
-		ops->obj_get_bsize &&
 
 		/* AllocBuf/FreeBuf interfaces are not in use right now. */
 #if 0

--- a/src/dstore/plugins/cortx/cortx_dstore.c
+++ b/src/dstore/plugins/cortx/cortx_dstore.c
@@ -554,16 +554,6 @@ static void cortx_ds_io_op_fini(struct dstore_io_op *dop)
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 }
 
-ssize_t cortx_ds_obj_get_bsize(dstore_oid_t *oid)
-{
-	ssize_t bsize;
-	struct m0_uint128 fid;
-	m0_fid_copy((struct m0_uint128 *)oid, &fid);
-	bsize = m0store_get_bsize(fid);
-	log_debug("cortx_ds_obj_get_bsize bsize %lu", bsize);
-	return bsize;
-}
-
 const struct dstore_ops cortx_dstore_ops = {
 	.init = cortx_ds_init,
 	.fini = cortx_ds_fini,
@@ -576,5 +566,4 @@ const struct dstore_ops cortx_dstore_ops = {
 	.io_op_submit = cortx_ds_io_op_submit,
 	.io_op_wait = cortx_ds_io_op_wait,
 	.io_op_fini = cortx_ds_io_op_fini,
-	.obj_get_bsize = cortx_ds_obj_get_bsize,
 };

--- a/src/include/dstore.h
+++ b/src/include/dstore.h
@@ -108,9 +108,11 @@ int dstore_obj_write(struct dstore *dstore, void *ctx,
  * @paramp[in] obj - An open object.
  * @paramp[in] old_size - Current size of given object
  * @paramp[in] new_size - New size of a given object after performing this op
+ * @paramp[in] bsize - Block size of the associated file system
  * @return 0 on success -errno given by backend operation
  */
-int dstore_obj_resize(struct dstore_obj *obj, size_t old_size, size_t new_size);
+int dstore_obj_resize(struct dstore_obj *obj, size_t old_size, size_t new_size,
+		      size_t bsize);
 
 int dstore_get_new_objid(struct dstore *dstore, dstore_oid_t *oid);
 
@@ -146,9 +148,6 @@ typedef void (*dstore_io_op_cb_t)(void *cb_ctx,
 				  int op_rc);
 
 struct dstore *dstore_get(void);
-
-/* This api returns the block size from motr */
-ssize_t dstore_get_bsize(struct dstore *dstore, dstore_oid_t *oid);
 
 /** This API based on input decides whether the givevn request is aligned or not
  * If it is aligned request it will directly write the requested amount of data

--- a/src/test/ut/dsal_test_io.c
+++ b/src/test/ut/dsal_test_io.c
@@ -355,7 +355,7 @@ static void test_decrease_size_op(void **state)
 	ut_assert_int_equal(rc, 0);
 	free(write_buf);
 
-	rc = dstore_obj_resize(obj, 3000, 0);
+	rc = dstore_obj_resize(obj, 3000, 0, bs);
 	ut_assert_int_equal(rc, 0);
 
 	count = 4096;
@@ -382,7 +382,7 @@ static void test_decrease_size_op(void **state)
 	ut_assert_int_equal(rc, 0);
 	free(write_buf);
 
-	rc = dstore_obj_resize(obj, 8192, 4096);
+	rc = dstore_obj_resize(obj, 8192, 4096, bs);
 	ut_assert_int_equal(rc, 0);
 
 	count = 8192;
@@ -413,7 +413,7 @@ static void test_decrease_size_op(void **state)
 	ut_assert_int_equal(rc, 0);
 	free(write_buf);
 
-	rc = dstore_obj_resize(obj, 7192, 3096);
+	rc = dstore_obj_resize(obj, 7192, 3096, bs);
 	ut_assert_int_equal(rc, 0);
 
 	count = 8192;


### PR DESCRIPTION
#  EOS-15064: cortxfs perf: Expose bsize as a per file system configurable param and stop using m0store_get_bsize (repo dsal)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


## Commit Message
commit 3d8b4f0fc678ea40b24076f397b03e26d74816fe
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Nov 23 06:31:26 2020 +0000

            EOS-15064: cortxfs perf: Expose bsize as a per file system configurable param and stop using m0store_get_bsize (repo dsal)
            List of modified files:
                modified:   src/dstore/dstore_base.c
                modified:   src/dstore/dstore_internal.h
                modified:   src/dstore/plugins/cortx/cortx_dstore.c
                modified:   src/include/dstore.h
                modified:   src/test/ut/dsal_test_io.c
            Change description:
                    Remove the usages of m0store_get_bsize and replace it with file system wide
                    configured block size param. This parameter is stored in the stat attribue
                    of the file system and its objects.
                    Associated updates in ut to reflect API changes.
            Unit test:
                    Using configured 4K block size:
                            Verified that with this change regular NFS IO (v4) is working.
                            UT runs are successful.
                            cthon run is successful.
                    Note: While using less that 4K block size (e.g. 1K, 2K), ganesha is crashing, this needs to be
                    debugged later.

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
