### PR TITLE
EOS-15281 Use m0_log via log_write facility.

### DIFF
--- a/src/dsal/dsal.c
+++ b/src/dsal/dsal.c
@@ -19,6 +19,8 @@
 
 #include "dsal.h"  /* header for dsal_init/dsal_fini */
 #include <debug.h> /* dassert */
+#include <m0log.h>
+const int  m0trace_common4 = 2814;
 
 static int dsal_initialized;
 
@@ -26,6 +28,10 @@ int dsal_init(struct collection_item *cfg, int flags)
 {
 	dassert(dsal_initialized == 0);
 	dsal_initialized++;
+
+	test_m0log_setup();
+	test_m0log_common1_setup((const void*)&m0trace_common4);
+
 	return dstore_init(cfg, flags);
 }
 
@@ -33,6 +39,9 @@ int dsal_fini(void)
 {
 	struct dstore *dstor = dstore_get();
         dassert(dstor != NULL);
+
+	m0log_fini();
+
 	return dstore_fini(dstor);
 }
 

--- a/src/dsal/dstore_bufvec.c
+++ b/src/dsal/dstore_bufvec.c
@@ -27,6 +27,7 @@
 #include <errno.h> /* errno values */
 #include "../dstore/dstore_internal.h"
 #include "debug.h" /* dassert */
+#include "common/log.h" /* log_* */
 
 int dstore_io_buf_init(void *data, size_t size, size_t offset,
 		      struct dstore_io_buf **buf)
@@ -92,6 +93,7 @@ int dstore_io_buf2vec(struct dstore_io_buf **buf, struct dstore_io_vec **vec)
 	dstore_io_vec_set_from_edbuf(result);
 	*vec = result;
 
+	log_test("************************* DSAL **************************** \n");
 out:
 	dassert((!(*vec)) || (*buf == NULL && dstore_io_vec_invariant(*vec)));
 	return rc;


### PR DESCRIPTION
Decoder code to have symbols in all modules.

Signed-off-by: Shipra <shipra.gupta@seagate.com>